### PR TITLE
Write logs to stdout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ default = ["log"]
 trace = []
 log = []
 
+# Enable to pipe log output to stdout instead of stderr
+use-stdout = []
+
 [dependencies]
 proc-macro2 = "1.0"
 quote = {version = "1.0"}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,10 +93,16 @@ pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 /// Expand the initialization code for the `log` crate.
 fn expand_logging_init() -> Tokens {
-  #[cfg(feature = "log")]
+  #[cfg(all(feature = "log", not(feature = "use-stdout")))]
   quote! {
     {
       let _ = ::env_logger::builder().is_test(true).try_init();
+    }
+  }
+  #[cfg(all(feature = "log", feature = "use-stdout"))]
+  quote! {
+    {
+      let _ = ::env_logger::builder().is_test(true).target(::env_logger::Target::Stdout).try_init();
     }
   }
   #[cfg(not(feature = "log"))]


### PR DESCRIPTION
Hi there, I was wondering if we can setup the logging environment to write logs to stdout.

After a bit of research it appears that cargo does not capture stderr of tests in the same ways as it captures stdout. I did not find a good answer why this is the case and how to circumvent it, so my idea is to configure the macro to write logs to stdout.

This is super helpful for debugging failed tests e.g. in automated pipelines.

This PR implements said functionality by using an optional feature that allows the user to opt in to write logs to stdout. Furthermore I think the default behavior should be changed to do exactly that, but as far as I think this is an API breaking change and would require a minor release.

Leave me a comment here whether you think these changes make sense; the default behavior should be changed to writing to stdout; we even need a feature flag; and I can update this MR accordingly.