### PR TITLE
Bump MSRV to 1.56

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
           profile: minimal
           # Please adjust README and rust-version field in Cargo.toml files when
           # bumping version.
-          toolchain: 1.49.0
+          toolchain: 1.56
           default: true
       - name: Build
         run: cargo build --locked --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Unreleased
 - Removed generated `test_impl` function, which could have "leaked" into
   test cases (#28)
 - Eliminated dependency on `tracing` crate
+- Bumped minimum supported Rust version to `1.56` and bumped syn dependency to
+  2.0
 
 
 0.2.12

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "test-log"
 version = "0.2.12"
 authors = ["Daniel Mueller <deso@posteo.net>"]
 edition = "2018"
+rust-version = "1.56"
 license = "Apache-2.0 OR MIT"
 homepage = "https://github.com/d-e-s-o/test-log"
 repository = "https://github.com/d-e-s-o/test-log.git"
@@ -37,7 +38,7 @@ log = []
 [dependencies]
 proc-macro2 = {version = "1.0.32", default-features = false}
 quote = {version = "1.0", default-features = false}
-syn = {version = "1.0.91", default-features = false, features = ["full", "parsing", "printing", "proc-macro"]}
+syn = {version = "2.0", default-features = false, features = ["full", "parsing", "printing", "proc-macro"]}
 
 [dev-dependencies]
 env_logger = {version = "0.9", default-features = false}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![pipeline](https://github.com/d-e-s-o/test-log/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/d-e-s-o/test-log/actions/workflows/test.yml)
 [![crates.io](https://img.shields.io/crates/v/test-log.svg)](https://crates.io/crates/test-log)
 [![Docs](https://docs.rs/test-log/badge.svg)](https://docs.rs/test-log)
-[![rustc](https://img.shields.io/badge/rustc-1.49+-blue.svg)](https://blog.rust-lang.org/2020/12/31/Rust-1.49.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.56+-blue.svg)](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html)
 
 test-log
 ========


### PR DESCRIPTION
This is the minimum version supported by syn 2.0 because it uses edition
2021 (earlier versions of cargo do not know about edition 2021).

Add rust-version to Cargo.toml which is also supported since 1.56.

Closes #29.
