### PR TITLE
Add #[test_log(default_log_filter = "___")]

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,0 +1,11 @@
+//! Use this file for iterating on the derive code. You can view the expanded code for any
+//! given configuration by updating this file and running:
+//!
+//! cargo expand --tests --example main
+
+#[test_log::test]
+fn works() {
+  assert_eq!(2 + 2, 4);
+}
+
+fn main() {}

--- a/tests/default_log_filter.rs
+++ b/tests/default_log_filter.rs
@@ -1,0 +1,12 @@
+//! This test needs to be defined in a separate file because it depends on global state
+//! (logger) and can't be run in parallel / in the same process with other tests to avoid
+//! flakiness (other tests initializing the env_logger first).
+
+#[test_log::test(tokio::test)]
+#[test_log(default_log_filter = "debug")]
+async fn with_inner_test_attribute_and_default_log_filter_defined() {
+  // Check that RUST_LOG isn't set, because that could affect the outcome of this
+  // test since we're checking that we fallback to "debug" if no RUST_LOG is set.
+  assert!(std::env::var(env_logger::DEFAULT_FILTER_ENV).is_err());
+  assert!(logging::log_enabled!(logging::Level::Debug));
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -10,13 +10,11 @@ use tracing::error;
 use tracing::info;
 use tracing::instrument;
 
-
 mod something {
   pub type Error = String;
 }
 
 use something::Error;
-
 
 #[test_log::test]
 fn without_return_type() {
@@ -68,6 +66,12 @@ async fn instrumented(input: usize) -> usize {
   result
 }
 
+/// To run the tracing tests and manually verify the output, run with the 'trace' feature:
+/// cargo test --features trace trace_with_custom_runtime -- --nocapture
+///
+/// Log level can be configured via the RUST_LOG env variable and span events for #[instrumented]
+/// can be configured via the RUST_LOG_SPAN_EVENTS env variable:
+/// RUST_LOG=debug RUST_LOG_SPAN_EVENTS=full cargo test --features trace trace_with_custom_runtime -- --nocapture
 #[test_log::test]
 fn trace_with_custom_runtime() {
   let rt = Builder::new_current_thread().build().unwrap();
@@ -81,6 +85,14 @@ fn trace_with_custom_runtime() {
 
 #[test_log::test(tokio::test)]
 async fn trace_with_tokio_attribute() {
+  instrumented(6).await;
+  instrumented(4).await;
+  debug!("done");
+}
+
+#[test_log::test(tokio::test)]
+#[test_log(default_log_filter = "info")]
+async fn trace_with_default_log_filter() {
   instrumented(6).await;
   instrumented(4).await;
   debug!("done");
@@ -108,7 +120,6 @@ impl<T> Foo for T {}
 /// initialization code.
 #[test_log::test]
 fn unambiguous_map() {}
-
 
 /// A module used for testing the `test` attribute after importing it
 /// via `use` instead of using fuller qualified syntax.


### PR DESCRIPTION
Users can now specify a default_log_filter via #[test_log(default_log_filter = "foo")] which will be used when RUST_LOG is not specified.

Please note that because env_logger is initialized globally, it is possible that this value will be ignored if the logger is already initialized.

Fixes: #25