### PR TITLE
Put 'default_log_filter' attribute behind 'unstable' feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Unreleased
 - Factored out `test-log-macros` crate to relieve users from having to
   care about tracing/logging dependencies themselves
 - Introduced `default_log_filter` attribute for setting the default log
-  filter on a per-test basis
+  filter on a per-test basis behind new `unstable` feature
 - Improved compile error output on wrong usage
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,13 +29,16 @@ include = ["src/lib.rs", "LICENSE-*", "README.md", "CHANGELOG.md"]
 
 [[test]]
 name = "default_log_filter"
-required-features = ["log"]
+required-features = ["log", "unstable"]
 
 [features]
 default = ["log"]
 # TODO: use "dep:{tracing-subscriber,evn_logger}" once our MSRV is 1.60 or higher.
 trace = ["tracing-subscriber", "test-log-macros/trace"]
 log = ["env_logger", "test-log-macros/log"]
+# Enable unstable features. These are generally exempt from any semantic
+# versioning guarantees.
+unstable = ["test-log-macros/unstable"]
 
 [workspace]
 members = ["macros"]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -12,6 +12,7 @@ proc-macro = true
 [features]
 trace = []
 log = []
+unstable = []
 
 [dependencies]
 proc-macro2 = {version = "1.0.32", default-features = false}

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -27,16 +27,20 @@ pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 fn parse_attrs(attrs: Vec<Attribute>) -> syn::Result<(AttributeArgs, Vec<Attribute>)> {
   let mut attribute_args = AttributeArgs::default();
-  let mut ignored_attrs = vec![];
-  for attr in attrs {
-    let matched = attribute_args.try_parse_attr_single(&attr)?;
-    // Keep only attrs that didn't match the #[test_log(_)] syntax.
-    if !matched {
-      ignored_attrs.push(attr);
+  if cfg!(feature = "unstable") {
+    let mut ignored_attrs = vec![];
+    for attr in attrs {
+      let matched = attribute_args.try_parse_attr_single(&attr)?;
+      // Keep only attrs that didn't match the #[test_log(_)] syntax.
+      if !matched {
+        ignored_attrs.push(attr);
+      }
     }
-  }
 
-  Ok((attribute_args, ignored_attrs))
+    Ok((attribute_args, ignored_attrs))
+  } else {
+    Ok((attribute_args, attrs))
+  }
 }
 
 fn try_test(attr: TokenStream, input: ItemFn) -> syn::Result<Tokens> {

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -99,6 +99,7 @@ async fn trace_with_tokio_attribute() {
   debug!("done");
 }
 
+#[cfg(feature = "unstable")]
 #[test_log::test(tokio::test)]
 #[test_log(default_log_filter = "info")]
 async fn trace_with_default_log_filter() {


### PR DESCRIPTION
The `default_log_filter`, while useful, is arguably a bit of a kludge given that it is inherently racy with respect to other tests initializing the corresponding log/tracing infrastructure beforehand. What we would really want is to make it a global attribute, but that is not currently possible on stable Rust.
Put this attribute behind a newly introduce feature, unstable, so that we have more flexibility for changing/removing it in the future, without being required to break semantic versioning guarantees.