### PR TITLE
include license files when publishing test-log-macros

### DIFF
--- a/macros/LICENSE-APACHE
+++ b/macros/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/macros/LICENSE-MIT
+++ b/macros/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
Both the MIT and Apache-2.0 licenses require that redistributed sources contain a copy of the original license text.

Adding symbolic links in the `macros` directory should be enough to have `cargo publish` include the files (unless you're running "cargo publish" on an OS that does not support symbolic links).