### PR TITLE
fix: append `#[::core::prelude::v1::test]` only if it does not exist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,3 +70,7 @@ tracing = {version = "0.1.20"}
 #
 # Probably fixed by https://github.com/rust-lang-nursery/lazy-static.rs/pull/107.
 _lazy_static_unused = { package = "lazy_static", version = "1.0.2" }
+
+[patch.crates-io]
+test-case = { git = "https://github.com/kezhuw/test-case.git", branch = "test-proc-macros-cooperation" }
+tokio = { git = "https://github.com/kezhuw/tokio.git", branch = "test-proc-macros-cooperation" }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -57,6 +57,36 @@ fn with_inner_test_attribute_and_test_args_and_panic(x: i8, _y: i8) {
   assert_eq!(x, 0);
 }
 
+#[tokio::test]
+#[test_log::test]
+async fn with_append_test_attribute_and_async() {
+  assert_eq!(async { 42 }.await, 42)
+}
+
+#[test_case::test_case(-2, -4)]
+#[test_case::test_case(-2, -5)]
+#[test_log::test]
+fn with_append_test_attribute_and_test_args(x: i8, _y: i8) {
+  assert_eq!(x, -2);
+}
+
+#[should_panic]
+#[test_case::test_case(-2, -4)]
+#[test_case::test_case(-3, -4)]
+#[test_log::test]
+fn with_append_test_attribute_and_test_args_and_panic(x: i8, _y: i8) {
+  assert_eq!(x, 0);
+}
+
+#[should_panic]
+#[test_case::test_case(-2, -4)]
+#[test_case::test_case(-3, -4)]
+#[tokio::test]
+#[test_log::test]
+async fn with_append_test_attribute_and_test_args_and_panic_async(x: i8, _y: i8) {
+  assert_eq!(x, 0);
+}
+
 #[instrument]
 async fn instrumented(input: usize) -> usize {
   info!("input = {}", input);


### PR DESCRIPTION
This way if preceding test macros add `#[::core::prelude::v1::test]` by appending, then we can avoid duplicated test runs.

See also frondeus/test-case#101, frondeus/test-case#143

Closes #35.


This pr depends on frondeus/test-case#143 and tokio-rs/tokio#6497.