### PR TITLE
fix: if tracing is enabled, use if for logging too

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ required-features = ["log", "unstable"]
 default = ["log"]
 # TODO: use "dep:{tracing-subscriber,evn_logger}" once our MSRV is 1.60 or higher.
 trace = ["tracing-subscriber", "test-log-macros/trace"]
-log = ["env_logger", "test-log-macros/log"]
+log = ["env_logger", "test-log-macros/log", "tracing-subscriber?/tracing-log"]
 # Enable unstable features. These are generally exempt from any semantic
 # versioning guarantees.
 unstable = ["test-log-macros/unstable"]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -151,7 +151,7 @@ impl AttributeArgs {
 
 
 /// Expand the initialization code for the `log` crate.
-#[cfg(feature = "log")]
+#[cfg(all(feature = "log", not(feature = "trace")))]
 fn expand_logging_init(attribute_args: &AttributeArgs) -> Tokens {
   let add_default_log_filter = if let Some(default_log_filter) = &attribute_args.default_log_filter
   {
@@ -172,7 +172,7 @@ fn expand_logging_init(attribute_args: &AttributeArgs) -> Tokens {
   }
 }
 
-#[cfg(not(feature = "log"))]
+#[cfg(not(all(feature = "log", not(feature = "trace"))))]
 fn expand_logging_init(_attribute_args: &AttributeArgs) -> Tokens {
   quote! {}
 }


### PR DESCRIPTION
When having crates which use `tracing` and `log` and have the `tracing` feature enabled, you'll get mixed log formats on the output:

```
2024-04-24T11:56:23.290168Z  INFO sea_orm_migration::migrator: Applying migration 'm0000220_create_package_relates_to_package'
2024-04-24T11:56:23.291295Z  INFO sea_orm_migration::migrator: Migration 'm0000220_create_package_relates_to_package' has been applied
2024-04-24T11:56:23.291484Z  INFO sea_orm_migration::migrator: Applying migration 'm0000230_create_qualified_package_transitive_function'
2024-04-24T11:56:23.291994Z  INFO sea_orm_migration::migrator: Migration 'm0000230_create_qualified_package_transitive_function' has been applied
2024-04-24T11:56:23.292199Z  INFO sea_orm_migration::migrator: Applying migration 'm0000240_create_importer'
2024-04-24T11:56:23.294018Z  INFO sea_orm_migration::migrator: Migration 'm0000240_create_importer' has been applied
[WARN  trustify_module_graph::graph::sbom::spdx] Replacing faulty SPDX license expression with NOASSERTION: Parsing for expression `Parsing for expression `GPLV2+,-LGPLV2+,-MIT` failed.` failed.
[WARN  trustify_module_graph::graph::sbom::spdx] Replacing faulty SPDX license expression with NOASSERTION: Parsing for expression `Parsing for expression `GPLV2+,-LGPLV2+,-MIT` failed.` failed.
[WARN  trustify_module_graph::graph::sbom::spdx] Replacing faulty SPDX license expression with NOASSERTION: Parsing for expression `Parsing for expression `GPLV2+,-LGPLV2+,-MIT` failed.` failed.
[WARN  trustify_module_graph::graph::sbom] unable to ingest relationships involving a non-fully-qualified package pkg://golang/github.com/openshift/ocs-operator
[WARN  trustify_module_graph::graph::sbom] unable to ingest relationships involving a non-fully-qualified package pkg://generic/gnulib
[WARN  trustify_module_graph::graph::sbom] unable to ingest relationships involving a non-fully-qualified package pkg://pypi/:sys-platform
[INFO  trustify_module_graph::graph::sbom::spdx] Package cache: PackageCache { cache: 8044, hits: 24040 }
```

This was due to the fact that we enabled the `trace` feature, but did not disable the `default` (and thus the `log`) feature. Having both enabled, will also enable both frameworks, one for logging, one for tracing.

Disabling the `log` feature however removes the `log` output.

I think the correct fix would be to enable the `tracing-subscriber/tracing-log` feature, which captures both `log` and `tracing` events, streaming both the `tracing` system, giving a consolidated format.

This would make the `log` and `trace` feature mutually exclusive.