### PR TITLE
Add support for tracing-flame

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ default = ["log"]
 # TODO: use "dep:{tracing-subscriber,evn_logger}" once our MSRV is 1.60 or higher.
 trace = ["tracing-subscriber", "tracing-subscriber/ansi", "tracing-subscriber/tracing-log", "test-log-macros/trace"]
 log = ["env_logger", "test-log-macros/log"]
+tracing-flame = ["trace", "dep:tracing-flame"]
 # Enable unstable features. These are generally exempt from any semantic
 # versioning guarantees.
 unstable = ["test-log-macros/unstable"]
@@ -48,6 +49,8 @@ members = ["macros"]
 test-log-macros = {version = "0.2.15", path = "macros"}
 tracing-subscriber = {version = "0.3.17", default-features = false, optional = true, features = ["env-filter", "fmt"]}
 env_logger = {version = "0.11", default-features = false, optional = true}
+
+tracing-flame = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 logging = {version = "0.4.8", package = "log"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ required-features = ["log", "unstable"]
 [features]
 default = ["log"]
 # TODO: use "dep:{tracing-subscriber,evn_logger}" once our MSRV is 1.60 or higher.
-trace = ["tracing-subscriber", "test-log-macros/trace"]
+trace = ["tracing-subscriber", "tracing-subscriber/tracing-log", "test-log-macros/trace"]
 log = ["env_logger", "test-log-macros/log"]
 # Enable unstable features. These are generally exempt from any semantic
 # versioning guarantees.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ required-features = ["log", "unstable"]
 [features]
 default = ["log"]
 # TODO: use "dep:{tracing-subscriber,evn_logger}" once our MSRV is 1.60 or higher.
-trace = ["tracing-subscriber", "tracing-subscriber/tracing-log", "test-log-macros/trace"]
+trace = ["tracing-subscriber", "tracing-subscriber/ansi", "tracing-subscriber/tracing-log", "test-log-macros/trace"]
 log = ["env_logger", "test-log-macros/log"]
 # Enable unstable features. These are generally exempt from any semantic
 # versioning guarantees.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,3 +68,7 @@ pub use tracing_subscriber;
 #[cfg(feature = "log")]
 #[doc(hidden)]
 pub use env_logger;
+
+#[cfg(feature = "trace")]
+#[doc(hidden)]
+pub mod tracing;

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -1,17 +1,66 @@
 //! Support for tracing
 
 use std::env::var_os;
+use std::fs::File;
+use std::io::BufWriter;
+use std::path::Path;
 use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+#[derive(Default)]
+pub struct TracingGuard {
+  #[cfg(feature = "tracing-flame")]
+  _flame: Option<tracing_flame::FlushGuard<BufWriter<File>>>,
+}
 
 /// Initialize the tracing
-pub fn init(env_filter: impl Into<tracing_subscriber::EnvFilter>) {
+pub fn init(name: &str, env_filter: impl Into<tracing_subscriber::EnvFilter>) -> TracingGuard {
+  let env_filter = env_filter.into();
   let event_filter = eval_event_filter();
 
-  let _ = tracing_subscriber::FmtSubscriber::builder()
-    .with_env_filter(env_filter)
+  let fmt = tracing_subscriber::fmt::layer()
+    .with_ansi(true)
     .with_span_events(event_filter)
+    .with_level(true)
     .with_test_writer()
-    .try_init();
+    .compact();
+
+  let layered = tracing_subscriber::registry().with(env_filter).with(fmt);
+
+  #[cfg(feature = "tracing-flame")]
+  {
+    return match std::env::var("TEST_LOG_FLAMES").ok() {
+      Some(base) => {
+        let path = format!("{base}/{name}.folded");
+        let path = Path::new(&path);
+
+        // ensure we have the parent dir
+        if let Some(parent) = path.parent() {
+          let _ = std::fs::create_dir_all(parent);
+        }
+
+        let (flame, guard) =
+          tracing_flame::FlameLayer::with_file(path).expect("Unable to initialize tracing-flame");
+
+        let _ = layered.with(flame).try_init();
+
+        TracingGuard {
+          _flame: Some(guard),
+        }
+      },
+      None => {
+        let _ = layered.try_init();
+        TracingGuard::default()
+      },
+    };
+  }
+
+  #[cfg(not(feature = "tracing-flame"))]
+  {
+    let layered = layered.with(env_filter).with(fmt).try_init();
+    TracingGuard::default()
+  }
 }
 
 fn eval_event_filter() -> FmtSpan {

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -1,0 +1,45 @@
+//! Support for tracing
+
+use std::env::var_os;
+use tracing_subscriber::fmt::format::FmtSpan;
+
+/// Initialize the tracing
+pub fn init(env_filter: impl Into<tracing_subscriber::EnvFilter>) {
+  let event_filter = eval_event_filter();
+
+  let _ = tracing_subscriber::FmtSubscriber::builder()
+    .with_env_filter(env_filter)
+    .with_span_events(event_filter)
+    .with_test_writer()
+    .try_init();
+}
+
+fn eval_event_filter() -> FmtSpan {
+  match var_os("RUST_LOG_SPAN_EVENTS") {
+    Some(mut value) => {
+      value.make_ascii_lowercase();
+      let value = value
+        .to_str()
+        .expect("test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8");
+      value
+        .split(",")
+        .map(|filter| match filter.trim() {
+          "new" => FmtSpan::NEW,
+          "enter" => FmtSpan::ENTER,
+          "exit" => FmtSpan::EXIT,
+          "close" => FmtSpan::CLOSE,
+          "active" => FmtSpan::ACTIVE,
+          "full" => FmtSpan::FULL,
+          _ => panic!(
+            "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
+                  For example: `active` or `new,close`\n\t\
+                  Supported filters: new, enter, exit, close, active, full\n\t\
+                  Got: {}",
+            value
+          ),
+        })
+        .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+    },
+    None => FmtSpan::NONE,
+  }
+}


### PR DESCRIPTION
This PR is based on #48. Only the last commit belongs to this PR.
---

This adds support for [tracing-flame](https://github.com/tokio-rs/tracing/tree/master/tracing-flame). (See #47)

This PR works, but might need some work on the documentation. I am happy to follow up with it if you think the approach is good in general.

Here is how this works:

* Enable the `tracing-flame` feature on `test-log` (this by itself doesn't to much other than adding the dependency).
* Setting the `TEST_LOG_FLAMES` env-var to a path when running tests, will write traced out as `{module}/{name}.folded`.
* Those can be processed with `inferno` as described by `tracing-flames`

The result of this looks something like:

![image](https://github.com/d-e-s-o/test-log/assets/202474/04b1b9a0-2e1a-4575-809c-02fd8496db27)