### PR TITLE
Support `no_std`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
         cargo build --profile=${{ matrix.profile }}
         cargo build --all-features --profile=${{ matrix.profile }}
         cargo test --profile=${{ matrix.profile }}
+        cargo test --no-default-features --features trace no_std_required --profile=${{ matrix.profile }}
   build-minimum:
     name: Build using minimum versions of dependencies
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,11 @@ tracing infrastructure before running tests.
 include = ["src/lib.rs", "LICENSE-*", "README.md", "CHANGELOG.md"]
 
 [[test]]
+name = "no_std_test"
+path = "tests/no_std_required.rs"
+required-features = ["trace"]
+
+[[test]]
 name = "default_log_filter"
 path = "tests/default_log_filter.rs"
 required-features = ["log", "unstable"]
@@ -36,7 +41,7 @@ required-features = ["log", "unstable"]
 default = ["log", "color", "std"]
 std = ["test-log-macros/std"]
 trace = ["dep:tracing-subscriber", "test-log-macros/trace"]
-log = ["dep:env_logger", "test-log-macros/log", "tracing-subscriber?/tracing-log"]
+log = ["dep:env_logger", "test-log-macros/log", "tracing-subscriber?/tracing-log", "std"]
 color = ["env_logger?/auto-color", "tracing-subscriber?/ansi"]
 # Enable unstable features. These are generally exempt from any semantic
 # versioning guarantees.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,8 @@ path = "tests/default_log_filter.rs"
 required-features = ["log", "unstable"]
 
 [features]
-default = ["log", "color"]
+default = ["log", "color", "std"]
+std = ["test-log-macros/std"]
 trace = ["dep:tracing-subscriber", "test-log-macros/trace"]
 log = ["dep:env_logger", "test-log-macros/log", "tracing-subscriber?/tracing-log"]
 color = ["env_logger?/auto-color", "tracing-subscriber?/ansi"]
@@ -45,7 +46,7 @@ unstable = ["test-log-macros/unstable"]
 members = ["macros"]
 
 [dependencies]
-test-log-macros = {version = "0.2.15", path = "macros"}
+test-log-macros = {version = "0.2.15", default-features = false, path = "macros"}
 tracing-subscriber = {version = "0.3.17", default-features = false, optional = true, features = ["env-filter", "fmt"]}
 env_logger = {version = "0.11", default-features = false, optional = true}
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -14,6 +14,8 @@ Supporting procedural macro crate for test-log.
 proc-macro = true
 
 [features]
+default = ["std"]
+std = []
 trace = []
 log = []
 unstable = []

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -3,14 +3,12 @@
 
 #![no_std]
 
-extern crate proc_macro;
 extern crate alloc;
+extern crate proc_macro;
 
-use alloc::{
-	string::String,
-	vec,
-	vec::Vec,
-};
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as Tokens;

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,7 +1,16 @@
 // Copyright (C) 2019-2023 Daniel Mueller <deso@posteo.net>
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+#![no_std]
+
 extern crate proc_macro;
+extern crate alloc;
+
+use alloc::{
+	string::String,
+	vec,
+	vec::Vec,
+};
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as Tokens;
@@ -199,10 +208,8 @@ fn expand_tracing_init(attribute_args: &AttributeArgs) -> Tokens {
       let __internal_event_filter = {
         use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
 
-        match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
+        match ::core::option_env!("RUST_LOG_SPAN_EVENTS") {
           Some(mut value) => {
-            value.make_ascii_lowercase();
-            let value = value.to_str().expect("test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8");
             value
               .split(",")
               .map(|filter| match filter.trim() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 #![deny(missing_docs)]
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 //! A crate providing a replacement #[[macro@test]] attribute that
 //! initializes logging and/or tracing infrastructure before running

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 #![deny(missing_docs)]
+#![no_std]
 
 //! A crate providing a replacement #[[macro@test]] attribute that
 //! initializes logging and/or tracing infrastructure before running

--- a/tests/no_std_required.rs
+++ b/tests/no_std_required.rs
@@ -4,7 +4,7 @@ use test_log::test;
 use tracing::debug;
 
 #[test]
-fn test_without_std() {
+fn no_std_required() {
   debug!("It works without std!");
   assert_eq!(1 + 1, 2);
 }

--- a/tests/no_std_required.rs
+++ b/tests/no_std_required.rs
@@ -1,0 +1,10 @@
+#![no_std]
+
+use test_log::test;
+use tracing::debug;
+
+#[test]
+fn test_without_std() {
+  debug!("It works without std!");
+  assert_eq!(1 + 1, 2);
+}


### PR DESCRIPTION
I'm writing a library that needs to be tested *inside `no_std` environments*.
Since `tracing`, and `tracing-subscriber` do not inherently require `std`, it would be convenient to be able to use this crate to do so.

I've made some trivial changes, like importing `alloc::{string::String, vec::Vec}`, but the more important change is that I've switched `std::env::var_os` with `core::option_env`, which resolves an optional environment variable *at compile time*. I'm fine feature gating the `std::env::var_os` call behind an `std` feature if that is more acceptable for you.

Some things to consider:

- You may want to enable [`std_instead_of_alloc`](https://rust-lang.github.io/rust-clippy/rust-1.78.0/index.html#/alloc) to identify types up front that can be easily used without `std`
- You may want an `std` flag to enable more features available via `std` that are not required for the base crate to work.

Thanks for all your work; I really enjoy this crate!

—Tait
