### PR TITLE
Capture INFO and WARN from tracing by default

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -191,7 +191,13 @@ fn expand_tracing_init(attribute_args: &AttributeArgs) -> Tokens {
         .from_env_lossy()
     }
   } else {
-    quote! { ::test_log::tracing_subscriber::EnvFilter::from_default_env() }
+    quote! {
+      ::test_log::tracing_subscriber::EnvFilter::builder()
+        .with_default_directive(
+          ::test_log::tracing_subscriber::filter::LevelFilter::INFO.into()
+        )
+        .from_env_lossy()
+    }
   };
 
   quote! {


### PR DESCRIPTION
Previously, we only captured ERROR, and required users to set RUST_LOG=info explicitly when running tests.

Fixes #53