### PR TITLE
add support for rstest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         cargo build --profile=${{ matrix.profile }}
         cargo build --all-features --profile=${{ matrix.profile }}
-        cargo test --profile=${{ matrix.profile }}
+        cargo test --profile=${{ matrix.profile }} --features rstest
   build-minimum:
     name: Build using minimum versions of dependencies
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,13 +30,14 @@ include = ["src/lib.rs", "LICENSE-*", "README.md", "CHANGELOG.md"]
 [[test]]
 name = "default_log_filter"
 path = "tests/default_log_filter.rs"
-required-features = ["log", "unstable"]
+required-features = ["log", "rstest", "unstable"]
 
 [features]
 default = ["log", "color"]
 trace = ["dep:tracing-subscriber", "test-log-macros/trace"]
 log = ["dep:env_logger", "test-log-macros/log", "tracing-subscriber?/tracing-log"]
 color = ["env_logger?/auto-color", "tracing-subscriber?/ansi"]
+rstest = ["test-log-macros/rstest"]
 # Enable unstable features. These are generally exempt from any semantic
 # versioning guarantees.
 unstable = ["test-log-macros/unstable"]
@@ -52,5 +53,6 @@ env_logger = {version = "0.11", default-features = false, optional = true}
 [dev-dependencies]
 logging = {version = "0.4.8", package = "log"}
 test-case = {version = "3.1"}
+rstest = {version = "0.25.0"}
 tokio = {version = "1.0", default-features = false, features = ["rt-multi-thread", "macros"]}
 tracing = {version = "0.1.20"}

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ The crate comes with two features pertaining "backend" initialization:
   crate.
 - `trace`, disabled by default, controls initialization for the
   `tracing` crate.
+- `rstest`, disabled by default, allows usage of this library with
+  [rstest](https://github.com/la10736/rstest)
 
 Depending on what backend the crate-under-test (and its dependencies)
 use, the respective feature(s) should be enabled to make messages that
@@ -91,6 +93,39 @@ are emitted by the test manifest on the terminal.
 
 On top of that, the `color` feature (enabled by default) controls
 whether to color output by default.
+
+#### Usage with rstest
+
+The same syntax is supported for rstest as with regular tests, just
+with swapping out `rstest` for `test`:
+```rust
+use test_log::rstest;
+
+#[rstest]
+fn it_works() {
+  info!("Checking whether it still works...");
+  assert_eq!(2 + 2, 4);
+  info!("Looks good!");
+}
+```
+
+You can use `#[case]` statements as normal:
+```rust
+#[rstest]
+#[case(4)]
+fn it_works(#[case] val: i64) {
+  // ...
+}
+```
+
+As well as wrapping other attributes, such as `tokio::test`:
+```rust
+#[rstest(tokio::test)]
+#[case(4)]
+async fn it_works(#[case] val: i64) {
+  // ...
+}
+```
 
 #### Logging Configuration
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -16,6 +16,7 @@ proc-macro = true
 [features]
 trace = []
 log = []
+rstest = []
 unstable = []
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,9 @@
 /// ```
 pub use test_log_macros::test;
 
+#[cfg(feature = "rstest")]
+pub use test_log_macros::rstest;
+
 #[cfg(feature = "trace")]
 #[doc(hidden)]
 pub use tracing_subscriber;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -99,6 +99,34 @@ async fn trace_with_tokio_attribute() {
   debug!("done");
 }
 
+#[cfg(feature = "rstest")]
+#[test_log::rstest]
+fn rstest() {
+  assert_eq!(2 + 2, 4);
+}
+
+#[cfg(feature = "rstest")]
+#[test_log::rstest(tokio::test)]
+async fn rstest_async() {
+  assert_eq!(async { 42 }.await, 42)
+}
+
+#[cfg(feature = "rstest")]
+#[test_log::rstest]
+#[case(1)]
+#[case(2)]
+fn rstest_with_cases(#[case] val: i64) {
+  assert_eq!(val, val);
+}
+
+#[cfg(feature = "rstest")]
+#[test_log::rstest(tokio::test)]
+#[case(1)]
+#[case(2)]
+async fn rstest_with_cases_async(#[case] val: i64) {
+  assert_eq!(async { val }.await, val);
+}
+
 #[cfg(feature = "unstable")]
 #[test_log::test(tokio::test)]
 #[test_log(default_log_filter = "info")]


### PR DESCRIPTION
# Description

This adds support for using [rstest](https://github.com/la10736/rstest) with test_log, by simply wrapping the `#[rstest]` macro in the same way that test_log wraps the `#[test]` macro.  The syntax for `rstest` is a little different, but not unreasonably so.  We just need to desugar this:

```rust
#[rstest(tokio::test)]
#[case(...)]
#[case(...)]
async fn test_blah(#[case] ...) { ... }
```

into this:

```rust
#[rstest]
#[case(...)]
#[case(...)]
#[tokio::test]
async fn test_blah(#[case] ...) { ... }
```

I put everything behind a feature flag so that folks who aren't using `rstest` don't have to worry about it.

# Testing done

- Updated the integration tests
- Replaced all the tests in my project with test_log and it works