### PR TITLE
Bump version of tracing-subscriber that fixes vuln

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ unstable = ["test-log-macros/unstable"]
 
 [dependencies]
 test-log-macros = {version = "0.2.18", path = "macros"}
-tracing-subscriber = {version = "0.3.17", default-features = false, optional = true, features = ["env-filter", "fmt"]}
+tracing-subscriber = {version = "0.3.20", default-features = false, optional = true, features = ["env-filter", "fmt"]}
 env_logger = {version = "0.11", default-features = false, optional = true}
 
 [dev-dependencies]


### PR DESCRIPTION
This commit fixes a vuln in tracing-subscriber, see RUSTSEC-2025-0055.