### PR TITLE
Suggest using [dev-dependencies] instead of [dependencies] in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ async fn it_also_works() {
 
 ```toml
 # Cargo.toml
-[dependencies]
+[dev-dependencies]
 # PICK ONE OF THE FOLLOWING:
 
 # Support `log` crate only (default).


### PR DESCRIPTION
As far as I understand, this crate will typically be used when running tests, so it should be sufficient to list it as a dev-dependency.