### PR TITLE
Fix spans for rust-analyzer

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,6 +30,7 @@ syn = { version = "2.0", default-features = false, features = ["full", "parsing"
 [dev-dependencies]
 insta = { version = "1.47", default-features = false }
 prettyplease = "0.2"
+proc-macro2 = { version = "1.0", features = ["span-locations"] }
 quote = { version = "1.0" }
 syn = { version = "2.0", features = ["full", "parsing"] }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -94,7 +94,7 @@ pub fn try_test(attr: Tokens, input: ItemFn) -> syn::Result<Tokens> {
     (quote! { #[#attr] }, quote! {})
   };
 
-  // Splice the initialization prologue into the existing block, so that
+  // Insert the initialization prologue into the existing block, so that
   // the fn body keeps its original source spans. Building a fresh outer
   // block with `quote!` here would give it a span covering the whole
   // annotated fn. That makes rust-analyzer generate spurious
@@ -122,8 +122,8 @@ pub fn try_test(attr: Tokens, input: ItemFn) -> syn::Result<Tokens> {
       init::init();
     }
   };
-  let prologue_stmts = syn::parse2::<syn::Block>(prologue)?.stmts;
-  block.stmts.splice(0..0, prologue_stmts);
+  let prologue_block: syn::Stmt = syn::parse2(prologue)?;
+  block.stmts.insert(0, prologue_block);
 
   let result = quote! {
     #inner_test

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -75,7 +75,7 @@ pub fn try_test(attr: Tokens, input: ItemFn) -> syn::Result<Tokens> {
     attrs,
     vis,
     sig,
-    block,
+    mut block,
   } = input;
 
   let (attribute_args, ignored_attrs) = parse_attrs(attrs)?;
@@ -94,11 +94,14 @@ pub fn try_test(attr: Tokens, input: ItemFn) -> syn::Result<Tokens> {
     (quote! { #[#attr] }, quote! {})
   };
 
-  let result = quote! {
-    #inner_test
-    #(#ignored_attrs)*
-    #generated_test
-    #vis #sig {
+  // Splice the initialization prologue into the existing block, so that
+  // the fn body keeps its original source spans. Building a fresh outer
+  // block with `quote!` here would give it a span covering the whole
+  // annotated fn. That makes rust-analyzer generate spurious
+  // jump-to-definition results for code inside the test; see
+  // <https://github.com/rust-lang/rust-analyzer/issues/20441>.
+  let prologue = quote! {
+    {
       // We put all initialization code into a separate module here in
       // order to prevent potential ambiguities that could result in
       // compilation errors. E.g., client code could use traits that
@@ -117,9 +120,16 @@ pub fn try_test(attr: Tokens, input: ItemFn) -> syn::Result<Tokens> {
       }
 
       init::init();
-
-      #block
     }
+  };
+  let prologue_stmts = syn::parse2::<syn::Block>(prologue)?.stmts;
+  block.stmts.splice(0..0, prologue_stmts);
+
+  let result = quote! {
+    #inner_test
+    #(#ignored_attrs)*
+    #generated_test
+    #vis #sig #block
   };
   Ok(result)
 }

--- a/core/tests/snapshots/snapshots__bare_test@log.snap
+++ b/core/tests/snapshots/snapshots__bare_test@log.snap
@@ -4,19 +4,22 @@ expression: output
 ---
 #[::core::prelude::v1::test]
 fn it_works() {
-  mod init {
-    pub fn init() {
-      {
-        let _result = ::test_log::env_logger::builder()
-          .parse_env(
-            ::test_log::env_logger::Env::default().default_filter_or("info"),
-          )
-          .target(::test_log::env_logger::Target::Stderr)
-          .is_test(true)
-          .try_init();
+  {
+    mod init {
+      pub fn init() {
+        {
+          let _result = ::test_log::env_logger::builder()
+            .parse_env(
+              ::test_log::env_logger::Env::default()
+                .default_filter_or("info"),
+            )
+            .target(::test_log::env_logger::Target::Stderr)
+            .is_test(true)
+            .try_init();
+        }
       }
     }
+    init::init();
   }
-  init::init();
   assert_eq!(2 + 2, 4);
 }

--- a/core/tests/snapshots/snapshots__bare_test@log.snap
+++ b/core/tests/snapshots/snapshots__bare_test@log.snap
@@ -18,7 +18,5 @@ fn it_works() {
     }
   }
   init::init();
-  {
-    assert_eq!(2 + 2, 4);
-  }
+  assert_eq!(2 + 2, 4);
 }

--- a/core/tests/snapshots/snapshots__bare_test@log_trace.snap
+++ b/core/tests/snapshots/snapshots__bare_test@log_trace.snap
@@ -4,60 +4,62 @@ expression: output
 ---
 #[::core::prelude::v1::test]
 fn it_works() {
-  mod init {
-    pub fn init() {
-      {
-        let __internal_event_filter = {
-          use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
-          match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
-            Some(mut value) => {
-              value.make_ascii_lowercase();
-              let value = value
-                .to_str()
-                .expect(
-                  "test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8",
-                );
-              value
-                .split(",")
-                .map(|filter| match filter.trim() {
-                  "new" => FmtSpan::NEW,
-                  "enter" => FmtSpan::ENTER,
-                  "exit" => FmtSpan::EXIT,
-                  "close" => FmtSpan::CLOSE,
-                  "active" => FmtSpan::ACTIVE,
-                  "full" => FmtSpan::FULL,
-                  _ => {
-                    panic!(
-                      "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
+  {
+    mod init {
+      pub fn init() {
+        {
+          let __internal_event_filter = {
+            use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
+            match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
+              Some(mut value) => {
+                value.make_ascii_lowercase();
+                let value = value
+                  .to_str()
+                  .expect(
+                    "test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8",
+                  );
+                value
+                  .split(",")
+                  .map(|filter| match filter.trim() {
+                    "new" => FmtSpan::NEW,
+                    "enter" => FmtSpan::ENTER,
+                    "exit" => FmtSpan::EXIT,
+                    "close" => FmtSpan::CLOSE,
+                    "active" => FmtSpan::ACTIVE,
+                    "full" => FmtSpan::FULL,
+                    _ => {
+                      panic!(
+                        "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
          For example: `active` or `new,close`\n\t\
          Supported filters: new, enter, exit, close, active, full\n\t\
          Got: {}",
-                      value
-                    )
-                  }
-                })
-                .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+                        value
+                      )
+                    }
+                  })
+                  .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+              }
+              None => FmtSpan::NONE,
             }
-            None => FmtSpan::NONE,
-          }
-        };
-        let _ = ::test_log::tracing_subscriber::FmtSubscriber::builder()
-          .with_env_filter(
-            ::test_log::tracing_subscriber::EnvFilter::builder()
-              .with_default_directive(
-                ::test_log::tracing_subscriber::filter::LevelFilter::INFO
-                  .into(),
-              )
-              .from_env_lossy(),
-          )
-          .with_span_events(__internal_event_filter)
-          .with_writer(
-            ::test_log::tracing_subscriber::fmt::TestWriter::with_stderr,
-          )
-          .try_init();
+          };
+          let _ = ::test_log::tracing_subscriber::FmtSubscriber::builder()
+            .with_env_filter(
+              ::test_log::tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(
+                  ::test_log::tracing_subscriber::filter::LevelFilter::INFO
+                    .into(),
+                )
+                .from_env_lossy(),
+            )
+            .with_span_events(__internal_event_filter)
+            .with_writer(
+              ::test_log::tracing_subscriber::fmt::TestWriter::with_stderr,
+            )
+            .try_init();
+        }
       }
     }
+    init::init();
   }
-  init::init();
   assert_eq!(2 + 2, 4);
 }

--- a/core/tests/snapshots/snapshots__bare_test@log_trace.snap
+++ b/core/tests/snapshots/snapshots__bare_test@log_trace.snap
@@ -59,7 +59,5 @@ fn it_works() {
     }
   }
   init::init();
-  {
-    assert_eq!(2 + 2, 4);
-  }
+  assert_eq!(2 + 2, 4);
 }

--- a/core/tests/snapshots/snapshots__bare_test@none.snap
+++ b/core/tests/snapshots/snapshots__bare_test@none.snap
@@ -8,7 +8,5 @@ fn it_works() {
     pub fn init() {}
   }
   init::init();
-  {
-    assert_eq!(2 + 2, 4);
-  }
+  assert_eq!(2 + 2, 4);
 }

--- a/core/tests/snapshots/snapshots__bare_test@none.snap
+++ b/core/tests/snapshots/snapshots__bare_test@none.snap
@@ -4,9 +4,11 @@ expression: output
 ---
 #[::core::prelude::v1::test]
 fn it_works() {
-  mod init {
-    pub fn init() {}
+  {
+    mod init {
+      pub fn init() {}
+    }
+    init::init();
   }
-  init::init();
   assert_eq!(2 + 2, 4);
 }

--- a/core/tests/snapshots/snapshots__bare_test@trace.snap
+++ b/core/tests/snapshots/snapshots__bare_test@trace.snap
@@ -4,60 +4,62 @@ expression: output
 ---
 #[::core::prelude::v1::test]
 fn it_works() {
-  mod init {
-    pub fn init() {
-      {
-        let __internal_event_filter = {
-          use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
-          match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
-            Some(mut value) => {
-              value.make_ascii_lowercase();
-              let value = value
-                .to_str()
-                .expect(
-                  "test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8",
-                );
-              value
-                .split(",")
-                .map(|filter| match filter.trim() {
-                  "new" => FmtSpan::NEW,
-                  "enter" => FmtSpan::ENTER,
-                  "exit" => FmtSpan::EXIT,
-                  "close" => FmtSpan::CLOSE,
-                  "active" => FmtSpan::ACTIVE,
-                  "full" => FmtSpan::FULL,
-                  _ => {
-                    panic!(
-                      "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
+  {
+    mod init {
+      pub fn init() {
+        {
+          let __internal_event_filter = {
+            use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
+            match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
+              Some(mut value) => {
+                value.make_ascii_lowercase();
+                let value = value
+                  .to_str()
+                  .expect(
+                    "test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8",
+                  );
+                value
+                  .split(",")
+                  .map(|filter| match filter.trim() {
+                    "new" => FmtSpan::NEW,
+                    "enter" => FmtSpan::ENTER,
+                    "exit" => FmtSpan::EXIT,
+                    "close" => FmtSpan::CLOSE,
+                    "active" => FmtSpan::ACTIVE,
+                    "full" => FmtSpan::FULL,
+                    _ => {
+                      panic!(
+                        "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
          For example: `active` or `new,close`\n\t\
          Supported filters: new, enter, exit, close, active, full\n\t\
          Got: {}",
-                      value
-                    )
-                  }
-                })
-                .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+                        value
+                      )
+                    }
+                  })
+                  .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+              }
+              None => FmtSpan::NONE,
             }
-            None => FmtSpan::NONE,
-          }
-        };
-        let _ = ::test_log::tracing_subscriber::FmtSubscriber::builder()
-          .with_env_filter(
-            ::test_log::tracing_subscriber::EnvFilter::builder()
-              .with_default_directive(
-                ::test_log::tracing_subscriber::filter::LevelFilter::INFO
-                  .into(),
-              )
-              .from_env_lossy(),
-          )
-          .with_span_events(__internal_event_filter)
-          .with_writer(
-            ::test_log::tracing_subscriber::fmt::TestWriter::with_stderr,
-          )
-          .try_init();
+          };
+          let _ = ::test_log::tracing_subscriber::FmtSubscriber::builder()
+            .with_env_filter(
+              ::test_log::tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(
+                  ::test_log::tracing_subscriber::filter::LevelFilter::INFO
+                    .into(),
+                )
+                .from_env_lossy(),
+            )
+            .with_span_events(__internal_event_filter)
+            .with_writer(
+              ::test_log::tracing_subscriber::fmt::TestWriter::with_stderr,
+            )
+            .try_init();
+        }
       }
     }
+    init::init();
   }
-  init::init();
   assert_eq!(2 + 2, 4);
 }

--- a/core/tests/snapshots/snapshots__bare_test@trace.snap
+++ b/core/tests/snapshots/snapshots__bare_test@trace.snap
@@ -59,7 +59,5 @@ fn it_works() {
     }
   }
   init::init();
-  {
-    assert_eq!(2 + 2, 4);
-  }
+  assert_eq!(2 + 2, 4);
 }

--- a/core/tests/snapshots/snapshots__default_log_filter@log_trace.snap
+++ b/core/tests/snapshots/snapshots__default_log_filter@log_trace.snap
@@ -60,5 +60,4 @@ fn with_filter() {
     }
   }
   init::init();
-  {}
 }

--- a/core/tests/snapshots/snapshots__default_log_filter@log_trace.snap
+++ b/core/tests/snapshots/snapshots__default_log_filter@log_trace.snap
@@ -4,60 +4,62 @@ expression: output
 ---
 #[::core::prelude::v1::test]
 fn with_filter() {
-  mod init {
-    pub fn init() {
-      {
-        let __internal_event_filter = {
-          use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
-          match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
-            Some(mut value) => {
-              value.make_ascii_lowercase();
-              let value = value
-                .to_str()
-                .expect(
-                  "test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8",
-                );
-              value
-                .split(",")
-                .map(|filter| match filter.trim() {
-                  "new" => FmtSpan::NEW,
-                  "enter" => FmtSpan::ENTER,
-                  "exit" => FmtSpan::EXIT,
-                  "close" => FmtSpan::CLOSE,
-                  "active" => FmtSpan::ACTIVE,
-                  "full" => FmtSpan::FULL,
-                  _ => {
-                    panic!(
-                      "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
+  {
+    mod init {
+      pub fn init() {
+        {
+          let __internal_event_filter = {
+            use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
+            match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
+              Some(mut value) => {
+                value.make_ascii_lowercase();
+                let value = value
+                  .to_str()
+                  .expect(
+                    "test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8",
+                  );
+                value
+                  .split(",")
+                  .map(|filter| match filter.trim() {
+                    "new" => FmtSpan::NEW,
+                    "enter" => FmtSpan::ENTER,
+                    "exit" => FmtSpan::EXIT,
+                    "close" => FmtSpan::CLOSE,
+                    "active" => FmtSpan::ACTIVE,
+                    "full" => FmtSpan::FULL,
+                    _ => {
+                      panic!(
+                        "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
          For example: `active` or `new,close`\n\t\
          Supported filters: new, enter, exit, close, active, full\n\t\
          Got: {}",
-                      value
-                    )
-                  }
-                })
-                .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+                        value
+                      )
+                    }
+                  })
+                  .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+              }
+              None => FmtSpan::NONE,
             }
-            None => FmtSpan::NONE,
-          }
-        };
-        let _ = ::test_log::tracing_subscriber::FmtSubscriber::builder()
-          .with_env_filter(
-            ::test_log::tracing_subscriber::EnvFilter::builder()
-              .with_default_directive(
-                "debug"
-                  .parse()
-                  .expect("test-log: default_log_filter must be valid"),
-              )
-              .from_env_lossy(),
-          )
-          .with_span_events(__internal_event_filter)
-          .with_writer(
-            ::test_log::tracing_subscriber::fmt::TestWriter::with_stderr,
-          )
-          .try_init();
+          };
+          let _ = ::test_log::tracing_subscriber::FmtSubscriber::builder()
+            .with_env_filter(
+              ::test_log::tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(
+                  "debug"
+                    .parse()
+                    .expect("test-log: default_log_filter must be valid"),
+                )
+                .from_env_lossy(),
+            )
+            .with_span_events(__internal_event_filter)
+            .with_writer(
+              ::test_log::tracing_subscriber::fmt::TestWriter::with_stderr,
+            )
+            .try_init();
+        }
       }
     }
+    init::init();
   }
-  init::init();
 }

--- a/core/tests/snapshots/snapshots__inner_tokio_test@log.snap
+++ b/core/tests/snapshots/snapshots__inner_tokio_test@log.snap
@@ -18,7 +18,5 @@ async fn with_async() {
     }
   }
   init::init();
-  {
-    assert_eq!(async { 42 } . await, 42);
-  }
+  assert_eq!(async { 42 } . await, 42);
 }

--- a/core/tests/snapshots/snapshots__inner_tokio_test@log.snap
+++ b/core/tests/snapshots/snapshots__inner_tokio_test@log.snap
@@ -4,19 +4,22 @@ expression: output
 ---
 #[tokio::test]
 async fn with_async() {
-  mod init {
-    pub fn init() {
-      {
-        let _result = ::test_log::env_logger::builder()
-          .parse_env(
-            ::test_log::env_logger::Env::default().default_filter_or("info"),
-          )
-          .target(::test_log::env_logger::Target::Stderr)
-          .is_test(true)
-          .try_init();
+  {
+    mod init {
+      pub fn init() {
+        {
+          let _result = ::test_log::env_logger::builder()
+            .parse_env(
+              ::test_log::env_logger::Env::default()
+                .default_filter_or("info"),
+            )
+            .target(::test_log::env_logger::Target::Stderr)
+            .is_test(true)
+            .try_init();
+        }
       }
     }
+    init::init();
   }
-  init::init();
   assert_eq!(async { 42 } . await, 42);
 }

--- a/core/tests/snapshots/snapshots__inner_tokio_test@log_trace.snap
+++ b/core/tests/snapshots/snapshots__inner_tokio_test@log_trace.snap
@@ -4,60 +4,62 @@ expression: output
 ---
 #[tokio::test]
 async fn with_async() {
-  mod init {
-    pub fn init() {
-      {
-        let __internal_event_filter = {
-          use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
-          match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
-            Some(mut value) => {
-              value.make_ascii_lowercase();
-              let value = value
-                .to_str()
-                .expect(
-                  "test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8",
-                );
-              value
-                .split(",")
-                .map(|filter| match filter.trim() {
-                  "new" => FmtSpan::NEW,
-                  "enter" => FmtSpan::ENTER,
-                  "exit" => FmtSpan::EXIT,
-                  "close" => FmtSpan::CLOSE,
-                  "active" => FmtSpan::ACTIVE,
-                  "full" => FmtSpan::FULL,
-                  _ => {
-                    panic!(
-                      "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
+  {
+    mod init {
+      pub fn init() {
+        {
+          let __internal_event_filter = {
+            use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
+            match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
+              Some(mut value) => {
+                value.make_ascii_lowercase();
+                let value = value
+                  .to_str()
+                  .expect(
+                    "test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8",
+                  );
+                value
+                  .split(",")
+                  .map(|filter| match filter.trim() {
+                    "new" => FmtSpan::NEW,
+                    "enter" => FmtSpan::ENTER,
+                    "exit" => FmtSpan::EXIT,
+                    "close" => FmtSpan::CLOSE,
+                    "active" => FmtSpan::ACTIVE,
+                    "full" => FmtSpan::FULL,
+                    _ => {
+                      panic!(
+                        "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
          For example: `active` or `new,close`\n\t\
          Supported filters: new, enter, exit, close, active, full\n\t\
          Got: {}",
-                      value
-                    )
-                  }
-                })
-                .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+                        value
+                      )
+                    }
+                  })
+                  .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+              }
+              None => FmtSpan::NONE,
             }
-            None => FmtSpan::NONE,
-          }
-        };
-        let _ = ::test_log::tracing_subscriber::FmtSubscriber::builder()
-          .with_env_filter(
-            ::test_log::tracing_subscriber::EnvFilter::builder()
-              .with_default_directive(
-                ::test_log::tracing_subscriber::filter::LevelFilter::INFO
-                  .into(),
-              )
-              .from_env_lossy(),
-          )
-          .with_span_events(__internal_event_filter)
-          .with_writer(
-            ::test_log::tracing_subscriber::fmt::TestWriter::with_stderr,
-          )
-          .try_init();
+          };
+          let _ = ::test_log::tracing_subscriber::FmtSubscriber::builder()
+            .with_env_filter(
+              ::test_log::tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(
+                  ::test_log::tracing_subscriber::filter::LevelFilter::INFO
+                    .into(),
+                )
+                .from_env_lossy(),
+            )
+            .with_span_events(__internal_event_filter)
+            .with_writer(
+              ::test_log::tracing_subscriber::fmt::TestWriter::with_stderr,
+            )
+            .try_init();
+        }
       }
     }
+    init::init();
   }
-  init::init();
   assert_eq!(async { 42 } . await, 42);
 }

--- a/core/tests/snapshots/snapshots__inner_tokio_test@log_trace.snap
+++ b/core/tests/snapshots/snapshots__inner_tokio_test@log_trace.snap
@@ -59,7 +59,5 @@ async fn with_async() {
     }
   }
   init::init();
-  {
-    assert_eq!(async { 42 } . await, 42);
-  }
+  assert_eq!(async { 42 } . await, 42);
 }

--- a/core/tests/snapshots/snapshots__inner_tokio_test@none.snap
+++ b/core/tests/snapshots/snapshots__inner_tokio_test@none.snap
@@ -8,7 +8,5 @@ async fn with_async() {
     pub fn init() {}
   }
   init::init();
-  {
-    assert_eq!(async { 42 } . await, 42);
-  }
+  assert_eq!(async { 42 } . await, 42);
 }

--- a/core/tests/snapshots/snapshots__inner_tokio_test@none.snap
+++ b/core/tests/snapshots/snapshots__inner_tokio_test@none.snap
@@ -4,9 +4,11 @@ expression: output
 ---
 #[tokio::test]
 async fn with_async() {
-  mod init {
-    pub fn init() {}
+  {
+    mod init {
+      pub fn init() {}
+    }
+    init::init();
   }
-  init::init();
   assert_eq!(async { 42 } . await, 42);
 }

--- a/core/tests/snapshots/snapshots__inner_tokio_test@trace.snap
+++ b/core/tests/snapshots/snapshots__inner_tokio_test@trace.snap
@@ -4,60 +4,62 @@ expression: output
 ---
 #[tokio::test]
 async fn with_async() {
-  mod init {
-    pub fn init() {
-      {
-        let __internal_event_filter = {
-          use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
-          match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
-            Some(mut value) => {
-              value.make_ascii_lowercase();
-              let value = value
-                .to_str()
-                .expect(
-                  "test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8",
-                );
-              value
-                .split(",")
-                .map(|filter| match filter.trim() {
-                  "new" => FmtSpan::NEW,
-                  "enter" => FmtSpan::ENTER,
-                  "exit" => FmtSpan::EXIT,
-                  "close" => FmtSpan::CLOSE,
-                  "active" => FmtSpan::ACTIVE,
-                  "full" => FmtSpan::FULL,
-                  _ => {
-                    panic!(
-                      "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
+  {
+    mod init {
+      pub fn init() {
+        {
+          let __internal_event_filter = {
+            use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
+            match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
+              Some(mut value) => {
+                value.make_ascii_lowercase();
+                let value = value
+                  .to_str()
+                  .expect(
+                    "test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8",
+                  );
+                value
+                  .split(",")
+                  .map(|filter| match filter.trim() {
+                    "new" => FmtSpan::NEW,
+                    "enter" => FmtSpan::ENTER,
+                    "exit" => FmtSpan::EXIT,
+                    "close" => FmtSpan::CLOSE,
+                    "active" => FmtSpan::ACTIVE,
+                    "full" => FmtSpan::FULL,
+                    _ => {
+                      panic!(
+                        "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
          For example: `active` or `new,close`\n\t\
          Supported filters: new, enter, exit, close, active, full\n\t\
          Got: {}",
-                      value
-                    )
-                  }
-                })
-                .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+                        value
+                      )
+                    }
+                  })
+                  .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+              }
+              None => FmtSpan::NONE,
             }
-            None => FmtSpan::NONE,
-          }
-        };
-        let _ = ::test_log::tracing_subscriber::FmtSubscriber::builder()
-          .with_env_filter(
-            ::test_log::tracing_subscriber::EnvFilter::builder()
-              .with_default_directive(
-                ::test_log::tracing_subscriber::filter::LevelFilter::INFO
-                  .into(),
-              )
-              .from_env_lossy(),
-          )
-          .with_span_events(__internal_event_filter)
-          .with_writer(
-            ::test_log::tracing_subscriber::fmt::TestWriter::with_stderr,
-          )
-          .try_init();
+          };
+          let _ = ::test_log::tracing_subscriber::FmtSubscriber::builder()
+            .with_env_filter(
+              ::test_log::tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(
+                  ::test_log::tracing_subscriber::filter::LevelFilter::INFO
+                    .into(),
+                )
+                .from_env_lossy(),
+            )
+            .with_span_events(__internal_event_filter)
+            .with_writer(
+              ::test_log::tracing_subscriber::fmt::TestWriter::with_stderr,
+            )
+            .try_init();
+        }
       }
     }
+    init::init();
   }
-  init::init();
   assert_eq!(async { 42 } . await, 42);
 }

--- a/core/tests/snapshots/snapshots__inner_tokio_test@trace.snap
+++ b/core/tests/snapshots/snapshots__inner_tokio_test@trace.snap
@@ -59,7 +59,5 @@ async fn with_async() {
     }
   }
   init::init();
-  {
-    assert_eq!(async { 42 } . await, 42);
-  }
+  assert_eq!(async { 42 } . await, 42);
 }

--- a/core/tests/snapshots/snapshots__stacked_core_prelude_test@log.snap
+++ b/core/tests/snapshots/snapshots__stacked_core_prelude_test@log.snap
@@ -18,5 +18,4 @@ fn already_has_test() {
     }
   }
   init::init();
-  {}
 }

--- a/core/tests/snapshots/snapshots__stacked_core_prelude_test@log.snap
+++ b/core/tests/snapshots/snapshots__stacked_core_prelude_test@log.snap
@@ -4,18 +4,21 @@ expression: output
 ---
 #[::core::prelude::v1::test]
 fn already_has_test() {
-  mod init {
-    pub fn init() {
-      {
-        let _result = ::test_log::env_logger::builder()
-          .parse_env(
-            ::test_log::env_logger::Env::default().default_filter_or("info"),
-          )
-          .target(::test_log::env_logger::Target::Stderr)
-          .is_test(true)
-          .try_init();
+  {
+    mod init {
+      pub fn init() {
+        {
+          let _result = ::test_log::env_logger::builder()
+            .parse_env(
+              ::test_log::env_logger::Env::default()
+                .default_filter_or("info"),
+            )
+            .target(::test_log::env_logger::Target::Stderr)
+            .is_test(true)
+            .try_init();
+        }
       }
     }
+    init::init();
   }
-  init::init();
 }

--- a/core/tests/snapshots/snapshots__stacked_core_prelude_test@log_trace.snap
+++ b/core/tests/snapshots/snapshots__stacked_core_prelude_test@log_trace.snap
@@ -59,5 +59,4 @@ fn already_has_test() {
     }
   }
   init::init();
-  {}
 }

--- a/core/tests/snapshots/snapshots__stacked_core_prelude_test@log_trace.snap
+++ b/core/tests/snapshots/snapshots__stacked_core_prelude_test@log_trace.snap
@@ -4,59 +4,61 @@ expression: output
 ---
 #[::core::prelude::v1::test]
 fn already_has_test() {
-  mod init {
-    pub fn init() {
-      {
-        let __internal_event_filter = {
-          use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
-          match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
-            Some(mut value) => {
-              value.make_ascii_lowercase();
-              let value = value
-                .to_str()
-                .expect(
-                  "test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8",
-                );
-              value
-                .split(",")
-                .map(|filter| match filter.trim() {
-                  "new" => FmtSpan::NEW,
-                  "enter" => FmtSpan::ENTER,
-                  "exit" => FmtSpan::EXIT,
-                  "close" => FmtSpan::CLOSE,
-                  "active" => FmtSpan::ACTIVE,
-                  "full" => FmtSpan::FULL,
-                  _ => {
-                    panic!(
-                      "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
+  {
+    mod init {
+      pub fn init() {
+        {
+          let __internal_event_filter = {
+            use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
+            match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
+              Some(mut value) => {
+                value.make_ascii_lowercase();
+                let value = value
+                  .to_str()
+                  .expect(
+                    "test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8",
+                  );
+                value
+                  .split(",")
+                  .map(|filter| match filter.trim() {
+                    "new" => FmtSpan::NEW,
+                    "enter" => FmtSpan::ENTER,
+                    "exit" => FmtSpan::EXIT,
+                    "close" => FmtSpan::CLOSE,
+                    "active" => FmtSpan::ACTIVE,
+                    "full" => FmtSpan::FULL,
+                    _ => {
+                      panic!(
+                        "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
          For example: `active` or `new,close`\n\t\
          Supported filters: new, enter, exit, close, active, full\n\t\
          Got: {}",
-                      value
-                    )
-                  }
-                })
-                .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+                        value
+                      )
+                    }
+                  })
+                  .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+              }
+              None => FmtSpan::NONE,
             }
-            None => FmtSpan::NONE,
-          }
-        };
-        let _ = ::test_log::tracing_subscriber::FmtSubscriber::builder()
-          .with_env_filter(
-            ::test_log::tracing_subscriber::EnvFilter::builder()
-              .with_default_directive(
-                ::test_log::tracing_subscriber::filter::LevelFilter::INFO
-                  .into(),
-              )
-              .from_env_lossy(),
-          )
-          .with_span_events(__internal_event_filter)
-          .with_writer(
-            ::test_log::tracing_subscriber::fmt::TestWriter::with_stderr,
-          )
-          .try_init();
+          };
+          let _ = ::test_log::tracing_subscriber::FmtSubscriber::builder()
+            .with_env_filter(
+              ::test_log::tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(
+                  ::test_log::tracing_subscriber::filter::LevelFilter::INFO
+                    .into(),
+                )
+                .from_env_lossy(),
+            )
+            .with_span_events(__internal_event_filter)
+            .with_writer(
+              ::test_log::tracing_subscriber::fmt::TestWriter::with_stderr,
+            )
+            .try_init();
+        }
       }
     }
+    init::init();
   }
-  init::init();
 }

--- a/core/tests/snapshots/snapshots__stacked_core_prelude_test@none.snap
+++ b/core/tests/snapshots/snapshots__stacked_core_prelude_test@none.snap
@@ -8,5 +8,4 @@ fn already_has_test() {
     pub fn init() {}
   }
   init::init();
-  {}
 }

--- a/core/tests/snapshots/snapshots__stacked_core_prelude_test@none.snap
+++ b/core/tests/snapshots/snapshots__stacked_core_prelude_test@none.snap
@@ -4,8 +4,10 @@ expression: output
 ---
 #[::core::prelude::v1::test]
 fn already_has_test() {
-  mod init {
-    pub fn init() {}
+  {
+    mod init {
+      pub fn init() {}
+    }
+    init::init();
   }
-  init::init();
 }

--- a/core/tests/snapshots/snapshots__stacked_core_prelude_test@trace.snap
+++ b/core/tests/snapshots/snapshots__stacked_core_prelude_test@trace.snap
@@ -59,5 +59,4 @@ fn already_has_test() {
     }
   }
   init::init();
-  {}
 }

--- a/core/tests/snapshots/snapshots__stacked_core_prelude_test@trace.snap
+++ b/core/tests/snapshots/snapshots__stacked_core_prelude_test@trace.snap
@@ -4,59 +4,61 @@ expression: output
 ---
 #[::core::prelude::v1::test]
 fn already_has_test() {
-  mod init {
-    pub fn init() {
-      {
-        let __internal_event_filter = {
-          use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
-          match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
-            Some(mut value) => {
-              value.make_ascii_lowercase();
-              let value = value
-                .to_str()
-                .expect(
-                  "test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8",
-                );
-              value
-                .split(",")
-                .map(|filter| match filter.trim() {
-                  "new" => FmtSpan::NEW,
-                  "enter" => FmtSpan::ENTER,
-                  "exit" => FmtSpan::EXIT,
-                  "close" => FmtSpan::CLOSE,
-                  "active" => FmtSpan::ACTIVE,
-                  "full" => FmtSpan::FULL,
-                  _ => {
-                    panic!(
-                      "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
+  {
+    mod init {
+      pub fn init() {
+        {
+          let __internal_event_filter = {
+            use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
+            match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
+              Some(mut value) => {
+                value.make_ascii_lowercase();
+                let value = value
+                  .to_str()
+                  .expect(
+                    "test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8",
+                  );
+                value
+                  .split(",")
+                  .map(|filter| match filter.trim() {
+                    "new" => FmtSpan::NEW,
+                    "enter" => FmtSpan::ENTER,
+                    "exit" => FmtSpan::EXIT,
+                    "close" => FmtSpan::CLOSE,
+                    "active" => FmtSpan::ACTIVE,
+                    "full" => FmtSpan::FULL,
+                    _ => {
+                      panic!(
+                        "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
          For example: `active` or `new,close`\n\t\
          Supported filters: new, enter, exit, close, active, full\n\t\
          Got: {}",
-                      value
-                    )
-                  }
-                })
-                .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+                        value
+                      )
+                    }
+                  })
+                  .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+              }
+              None => FmtSpan::NONE,
             }
-            None => FmtSpan::NONE,
-          }
-        };
-        let _ = ::test_log::tracing_subscriber::FmtSubscriber::builder()
-          .with_env_filter(
-            ::test_log::tracing_subscriber::EnvFilter::builder()
-              .with_default_directive(
-                ::test_log::tracing_subscriber::filter::LevelFilter::INFO
-                  .into(),
-              )
-              .from_env_lossy(),
-          )
-          .with_span_events(__internal_event_filter)
-          .with_writer(
-            ::test_log::tracing_subscriber::fmt::TestWriter::with_stderr,
-          )
-          .try_init();
+          };
+          let _ = ::test_log::tracing_subscriber::FmtSubscriber::builder()
+            .with_env_filter(
+              ::test_log::tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(
+                  ::test_log::tracing_subscriber::filter::LevelFilter::INFO
+                    .into(),
+                )
+                .from_env_lossy(),
+            )
+            .with_span_events(__internal_event_filter)
+            .with_writer(
+              ::test_log::tracing_subscriber::fmt::TestWriter::with_stderr,
+            )
+            .try_init();
+        }
       }
     }
+    init::init();
   }
-  init::init();
 }

--- a/core/tests/snapshots/snapshots__stacked_test_attribute@log.snap
+++ b/core/tests/snapshots/snapshots__stacked_test_attribute@log.snap
@@ -18,5 +18,4 @@ fn already_has_test() {
     }
   }
   init::init();
-  {}
 }

--- a/core/tests/snapshots/snapshots__stacked_test_attribute@log.snap
+++ b/core/tests/snapshots/snapshots__stacked_test_attribute@log.snap
@@ -4,18 +4,21 @@ expression: output
 ---
 #[test]
 fn already_has_test() {
-  mod init {
-    pub fn init() {
-      {
-        let _result = ::test_log::env_logger::builder()
-          .parse_env(
-            ::test_log::env_logger::Env::default().default_filter_or("info"),
-          )
-          .target(::test_log::env_logger::Target::Stderr)
-          .is_test(true)
-          .try_init();
+  {
+    mod init {
+      pub fn init() {
+        {
+          let _result = ::test_log::env_logger::builder()
+            .parse_env(
+              ::test_log::env_logger::Env::default()
+                .default_filter_or("info"),
+            )
+            .target(::test_log::env_logger::Target::Stderr)
+            .is_test(true)
+            .try_init();
+        }
       }
     }
+    init::init();
   }
-  init::init();
 }

--- a/core/tests/snapshots/snapshots__stacked_test_attribute@log_trace.snap
+++ b/core/tests/snapshots/snapshots__stacked_test_attribute@log_trace.snap
@@ -59,5 +59,4 @@ fn already_has_test() {
     }
   }
   init::init();
-  {}
 }

--- a/core/tests/snapshots/snapshots__stacked_test_attribute@log_trace.snap
+++ b/core/tests/snapshots/snapshots__stacked_test_attribute@log_trace.snap
@@ -4,59 +4,61 @@ expression: output
 ---
 #[test]
 fn already_has_test() {
-  mod init {
-    pub fn init() {
-      {
-        let __internal_event_filter = {
-          use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
-          match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
-            Some(mut value) => {
-              value.make_ascii_lowercase();
-              let value = value
-                .to_str()
-                .expect(
-                  "test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8",
-                );
-              value
-                .split(",")
-                .map(|filter| match filter.trim() {
-                  "new" => FmtSpan::NEW,
-                  "enter" => FmtSpan::ENTER,
-                  "exit" => FmtSpan::EXIT,
-                  "close" => FmtSpan::CLOSE,
-                  "active" => FmtSpan::ACTIVE,
-                  "full" => FmtSpan::FULL,
-                  _ => {
-                    panic!(
-                      "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
+  {
+    mod init {
+      pub fn init() {
+        {
+          let __internal_event_filter = {
+            use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
+            match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
+              Some(mut value) => {
+                value.make_ascii_lowercase();
+                let value = value
+                  .to_str()
+                  .expect(
+                    "test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8",
+                  );
+                value
+                  .split(",")
+                  .map(|filter| match filter.trim() {
+                    "new" => FmtSpan::NEW,
+                    "enter" => FmtSpan::ENTER,
+                    "exit" => FmtSpan::EXIT,
+                    "close" => FmtSpan::CLOSE,
+                    "active" => FmtSpan::ACTIVE,
+                    "full" => FmtSpan::FULL,
+                    _ => {
+                      panic!(
+                        "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
          For example: `active` or `new,close`\n\t\
          Supported filters: new, enter, exit, close, active, full\n\t\
          Got: {}",
-                      value
-                    )
-                  }
-                })
-                .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+                        value
+                      )
+                    }
+                  })
+                  .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+              }
+              None => FmtSpan::NONE,
             }
-            None => FmtSpan::NONE,
-          }
-        };
-        let _ = ::test_log::tracing_subscriber::FmtSubscriber::builder()
-          .with_env_filter(
-            ::test_log::tracing_subscriber::EnvFilter::builder()
-              .with_default_directive(
-                ::test_log::tracing_subscriber::filter::LevelFilter::INFO
-                  .into(),
-              )
-              .from_env_lossy(),
-          )
-          .with_span_events(__internal_event_filter)
-          .with_writer(
-            ::test_log::tracing_subscriber::fmt::TestWriter::with_stderr,
-          )
-          .try_init();
+          };
+          let _ = ::test_log::tracing_subscriber::FmtSubscriber::builder()
+            .with_env_filter(
+              ::test_log::tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(
+                  ::test_log::tracing_subscriber::filter::LevelFilter::INFO
+                    .into(),
+                )
+                .from_env_lossy(),
+            )
+            .with_span_events(__internal_event_filter)
+            .with_writer(
+              ::test_log::tracing_subscriber::fmt::TestWriter::with_stderr,
+            )
+            .try_init();
+        }
       }
     }
+    init::init();
   }
-  init::init();
 }

--- a/core/tests/snapshots/snapshots__stacked_test_attribute@none.snap
+++ b/core/tests/snapshots/snapshots__stacked_test_attribute@none.snap
@@ -8,5 +8,4 @@ fn already_has_test() {
     pub fn init() {}
   }
   init::init();
-  {}
 }

--- a/core/tests/snapshots/snapshots__stacked_test_attribute@none.snap
+++ b/core/tests/snapshots/snapshots__stacked_test_attribute@none.snap
@@ -4,8 +4,10 @@ expression: output
 ---
 #[test]
 fn already_has_test() {
-  mod init {
-    pub fn init() {}
+  {
+    mod init {
+      pub fn init() {}
+    }
+    init::init();
   }
-  init::init();
 }

--- a/core/tests/snapshots/snapshots__stacked_test_attribute@trace.snap
+++ b/core/tests/snapshots/snapshots__stacked_test_attribute@trace.snap
@@ -59,5 +59,4 @@ fn already_has_test() {
     }
   }
   init::init();
-  {}
 }

--- a/core/tests/snapshots/snapshots__stacked_test_attribute@trace.snap
+++ b/core/tests/snapshots/snapshots__stacked_test_attribute@trace.snap
@@ -4,59 +4,61 @@ expression: output
 ---
 #[test]
 fn already_has_test() {
-  mod init {
-    pub fn init() {
-      {
-        let __internal_event_filter = {
-          use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
-          match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
-            Some(mut value) => {
-              value.make_ascii_lowercase();
-              let value = value
-                .to_str()
-                .expect(
-                  "test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8",
-                );
-              value
-                .split(",")
-                .map(|filter| match filter.trim() {
-                  "new" => FmtSpan::NEW,
-                  "enter" => FmtSpan::ENTER,
-                  "exit" => FmtSpan::EXIT,
-                  "close" => FmtSpan::CLOSE,
-                  "active" => FmtSpan::ACTIVE,
-                  "full" => FmtSpan::FULL,
-                  _ => {
-                    panic!(
-                      "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
+  {
+    mod init {
+      pub fn init() {
+        {
+          let __internal_event_filter = {
+            use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
+            match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
+              Some(mut value) => {
+                value.make_ascii_lowercase();
+                let value = value
+                  .to_str()
+                  .expect(
+                    "test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8",
+                  );
+                value
+                  .split(",")
+                  .map(|filter| match filter.trim() {
+                    "new" => FmtSpan::NEW,
+                    "enter" => FmtSpan::ENTER,
+                    "exit" => FmtSpan::EXIT,
+                    "close" => FmtSpan::CLOSE,
+                    "active" => FmtSpan::ACTIVE,
+                    "full" => FmtSpan::FULL,
+                    _ => {
+                      panic!(
+                        "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
          For example: `active` or `new,close`\n\t\
          Supported filters: new, enter, exit, close, active, full\n\t\
          Got: {}",
-                      value
-                    )
-                  }
-                })
-                .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+                        value
+                      )
+                    }
+                  })
+                  .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+              }
+              None => FmtSpan::NONE,
             }
-            None => FmtSpan::NONE,
-          }
-        };
-        let _ = ::test_log::tracing_subscriber::FmtSubscriber::builder()
-          .with_env_filter(
-            ::test_log::tracing_subscriber::EnvFilter::builder()
-              .with_default_directive(
-                ::test_log::tracing_subscriber::filter::LevelFilter::INFO
-                  .into(),
-              )
-              .from_env_lossy(),
-          )
-          .with_span_events(__internal_event_filter)
-          .with_writer(
-            ::test_log::tracing_subscriber::fmt::TestWriter::with_stderr,
-          )
-          .try_init();
+          };
+          let _ = ::test_log::tracing_subscriber::FmtSubscriber::builder()
+            .with_env_filter(
+              ::test_log::tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(
+                  ::test_log::tracing_subscriber::filter::LevelFilter::INFO
+                    .into(),
+                )
+                .from_env_lossy(),
+            )
+            .with_span_events(__internal_event_filter)
+            .with_writer(
+              ::test_log::tracing_subscriber::fmt::TestWriter::with_stderr,
+            )
+            .try_init();
+        }
       }
     }
+    init::init();
   }
-  init::init();
 }

--- a/core/tests/snapshots/snapshots__with_return_type@log.snap
+++ b/core/tests/snapshots/snapshots__with_return_type@log.snap
@@ -4,19 +4,22 @@ expression: output
 ---
 #[::core::prelude::v1::test]
 fn returns_result() -> Result<(), String> {
-  mod init {
-    pub fn init() {
-      {
-        let _result = ::test_log::env_logger::builder()
-          .parse_env(
-            ::test_log::env_logger::Env::default().default_filter_or("info"),
-          )
-          .target(::test_log::env_logger::Target::Stderr)
-          .is_test(true)
-          .try_init();
+  {
+    mod init {
+      pub fn init() {
+        {
+          let _result = ::test_log::env_logger::builder()
+            .parse_env(
+              ::test_log::env_logger::Env::default()
+                .default_filter_or("info"),
+            )
+            .target(::test_log::env_logger::Target::Stderr)
+            .is_test(true)
+            .try_init();
+        }
       }
     }
+    init::init();
   }
-  init::init();
   Ok(())
 }

--- a/core/tests/snapshots/snapshots__with_return_type@log.snap
+++ b/core/tests/snapshots/snapshots__with_return_type@log.snap
@@ -18,5 +18,5 @@ fn returns_result() -> Result<(), String> {
     }
   }
   init::init();
-  { Ok(()) }
+  Ok(())
 }

--- a/core/tests/snapshots/snapshots__with_return_type@log_trace.snap
+++ b/core/tests/snapshots/snapshots__with_return_type@log_trace.snap
@@ -59,5 +59,5 @@ fn returns_result() -> Result<(), String> {
     }
   }
   init::init();
-  { Ok(()) }
+  Ok(())
 }

--- a/core/tests/snapshots/snapshots__with_return_type@log_trace.snap
+++ b/core/tests/snapshots/snapshots__with_return_type@log_trace.snap
@@ -4,60 +4,62 @@ expression: output
 ---
 #[::core::prelude::v1::test]
 fn returns_result() -> Result<(), String> {
-  mod init {
-    pub fn init() {
-      {
-        let __internal_event_filter = {
-          use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
-          match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
-            Some(mut value) => {
-              value.make_ascii_lowercase();
-              let value = value
-                .to_str()
-                .expect(
-                  "test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8",
-                );
-              value
-                .split(",")
-                .map(|filter| match filter.trim() {
-                  "new" => FmtSpan::NEW,
-                  "enter" => FmtSpan::ENTER,
-                  "exit" => FmtSpan::EXIT,
-                  "close" => FmtSpan::CLOSE,
-                  "active" => FmtSpan::ACTIVE,
-                  "full" => FmtSpan::FULL,
-                  _ => {
-                    panic!(
-                      "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
+  {
+    mod init {
+      pub fn init() {
+        {
+          let __internal_event_filter = {
+            use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
+            match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
+              Some(mut value) => {
+                value.make_ascii_lowercase();
+                let value = value
+                  .to_str()
+                  .expect(
+                    "test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8",
+                  );
+                value
+                  .split(",")
+                  .map(|filter| match filter.trim() {
+                    "new" => FmtSpan::NEW,
+                    "enter" => FmtSpan::ENTER,
+                    "exit" => FmtSpan::EXIT,
+                    "close" => FmtSpan::CLOSE,
+                    "active" => FmtSpan::ACTIVE,
+                    "full" => FmtSpan::FULL,
+                    _ => {
+                      panic!(
+                        "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
          For example: `active` or `new,close`\n\t\
          Supported filters: new, enter, exit, close, active, full\n\t\
          Got: {}",
-                      value
-                    )
-                  }
-                })
-                .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+                        value
+                      )
+                    }
+                  })
+                  .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+              }
+              None => FmtSpan::NONE,
             }
-            None => FmtSpan::NONE,
-          }
-        };
-        let _ = ::test_log::tracing_subscriber::FmtSubscriber::builder()
-          .with_env_filter(
-            ::test_log::tracing_subscriber::EnvFilter::builder()
-              .with_default_directive(
-                ::test_log::tracing_subscriber::filter::LevelFilter::INFO
-                  .into(),
-              )
-              .from_env_lossy(),
-          )
-          .with_span_events(__internal_event_filter)
-          .with_writer(
-            ::test_log::tracing_subscriber::fmt::TestWriter::with_stderr,
-          )
-          .try_init();
+          };
+          let _ = ::test_log::tracing_subscriber::FmtSubscriber::builder()
+            .with_env_filter(
+              ::test_log::tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(
+                  ::test_log::tracing_subscriber::filter::LevelFilter::INFO
+                    .into(),
+                )
+                .from_env_lossy(),
+            )
+            .with_span_events(__internal_event_filter)
+            .with_writer(
+              ::test_log::tracing_subscriber::fmt::TestWriter::with_stderr,
+            )
+            .try_init();
+        }
       }
     }
+    init::init();
   }
-  init::init();
   Ok(())
 }

--- a/core/tests/snapshots/snapshots__with_return_type@none.snap
+++ b/core/tests/snapshots/snapshots__with_return_type@none.snap
@@ -8,5 +8,5 @@ fn returns_result() -> Result<(), String> {
     pub fn init() {}
   }
   init::init();
-  { Ok(()) }
+  Ok(())
 }

--- a/core/tests/snapshots/snapshots__with_return_type@none.snap
+++ b/core/tests/snapshots/snapshots__with_return_type@none.snap
@@ -4,9 +4,11 @@ expression: output
 ---
 #[::core::prelude::v1::test]
 fn returns_result() -> Result<(), String> {
-  mod init {
-    pub fn init() {}
+  {
+    mod init {
+      pub fn init() {}
+    }
+    init::init();
   }
-  init::init();
   Ok(())
 }

--- a/core/tests/snapshots/snapshots__with_return_type@trace.snap
+++ b/core/tests/snapshots/snapshots__with_return_type@trace.snap
@@ -59,5 +59,5 @@ fn returns_result() -> Result<(), String> {
     }
   }
   init::init();
-  { Ok(()) }
+  Ok(())
 }

--- a/core/tests/snapshots/snapshots__with_return_type@trace.snap
+++ b/core/tests/snapshots/snapshots__with_return_type@trace.snap
@@ -4,60 +4,62 @@ expression: output
 ---
 #[::core::prelude::v1::test]
 fn returns_result() -> Result<(), String> {
-  mod init {
-    pub fn init() {
-      {
-        let __internal_event_filter = {
-          use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
-          match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
-            Some(mut value) => {
-              value.make_ascii_lowercase();
-              let value = value
-                .to_str()
-                .expect(
-                  "test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8",
-                );
-              value
-                .split(",")
-                .map(|filter| match filter.trim() {
-                  "new" => FmtSpan::NEW,
-                  "enter" => FmtSpan::ENTER,
-                  "exit" => FmtSpan::EXIT,
-                  "close" => FmtSpan::CLOSE,
-                  "active" => FmtSpan::ACTIVE,
-                  "full" => FmtSpan::FULL,
-                  _ => {
-                    panic!(
-                      "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
+  {
+    mod init {
+      pub fn init() {
+        {
+          let __internal_event_filter = {
+            use ::test_log::tracing_subscriber::fmt::format::FmtSpan;
+            match ::std::env::var_os("RUST_LOG_SPAN_EVENTS") {
+              Some(mut value) => {
+                value.make_ascii_lowercase();
+                let value = value
+                  .to_str()
+                  .expect(
+                    "test-log: RUST_LOG_SPAN_EVENTS must be valid UTF-8",
+                  );
+                value
+                  .split(",")
+                  .map(|filter| match filter.trim() {
+                    "new" => FmtSpan::NEW,
+                    "enter" => FmtSpan::ENTER,
+                    "exit" => FmtSpan::EXIT,
+                    "close" => FmtSpan::CLOSE,
+                    "active" => FmtSpan::ACTIVE,
+                    "full" => FmtSpan::FULL,
+                    _ => {
+                      panic!(
+                        "test-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
          For example: `active` or `new,close`\n\t\
          Supported filters: new, enter, exit, close, active, full\n\t\
          Got: {}",
-                      value
-                    )
-                  }
-                })
-                .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+                        value
+                      )
+                    }
+                  })
+                  .fold(FmtSpan::NONE, |acc, filter| filter | acc)
+              }
+              None => FmtSpan::NONE,
             }
-            None => FmtSpan::NONE,
-          }
-        };
-        let _ = ::test_log::tracing_subscriber::FmtSubscriber::builder()
-          .with_env_filter(
-            ::test_log::tracing_subscriber::EnvFilter::builder()
-              .with_default_directive(
-                ::test_log::tracing_subscriber::filter::LevelFilter::INFO
-                  .into(),
-              )
-              .from_env_lossy(),
-          )
-          .with_span_events(__internal_event_filter)
-          .with_writer(
-            ::test_log::tracing_subscriber::fmt::TestWriter::with_stderr,
-          )
-          .try_init();
+          };
+          let _ = ::test_log::tracing_subscriber::FmtSubscriber::builder()
+            .with_env_filter(
+              ::test_log::tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(
+                  ::test_log::tracing_subscriber::filter::LevelFilter::INFO
+                    .into(),
+                )
+                .from_env_lossy(),
+            )
+            .with_span_events(__internal_event_filter)
+            .with_writer(
+              ::test_log::tracing_subscriber::fmt::TestWriter::with_stderr,
+            )
+            .try_init();
+        }
       }
     }
+    init::init();
   }
-  init::init();
   Ok(())
 }

--- a/core/tests/spans.rs
+++ b/core/tests/spans.rs
@@ -1,0 +1,87 @@
+// Copyright (C) 2026 Jason Orendorff <jason.orendorff@gmail.com>
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+//! Tests for accurate source spans.
+
+use std::ops::Range;
+use std::str::FromStr as _;
+
+use proc_macro2::TokenStream;
+use syn::ItemFn;
+use syn::Meta;
+
+/// Strip the `#[test_log::test(...)]` attribute off `input`, returning
+/// its argument tokens.
+fn take_test_log_args(input: &mut ItemFn) -> TokenStream {
+  let pos = input
+    .attrs
+    .iter()
+    .position(|a| {
+      let segs = &a.path().segments;
+      segs.len() == 2 && segs[0].ident == "test_log" && segs[1].ident == "test"
+    })
+    .expect("input must carry a #[test_log::test(...)] attribute");
+  let attr = input.attrs.remove(pos);
+  match attr.meta {
+    Meta::List(list) => list.tokens,
+    _ => TokenStream::new(),
+  }
+}
+
+/// Parse `src` (which must contain a single annotated function) and
+/// run it through `try_test`, returning `(input_block_byte_range,
+/// expanded_block_byte_range)`.
+fn expand_and_get_brace_ranges(src: &str) -> (Range<usize>, Range<usize>) {
+  let tokens = TokenStream::from_str(src).expect("parse source");
+  let mut input = syn::parse2::<ItemFn>(tokens).expect("parse fn");
+  let args = take_test_log_args(&mut input);
+  let input_range = input.block.brace_token.span.join().byte_range();
+
+  let expanded = test_log_core::try_test(args, input).expect("expansion succeeds");
+  let expanded_fn = syn::parse2::<ItemFn>(expanded).expect("re-parse expanded fn");
+  let expanded_range = expanded_fn.block.brace_token.span.join().byte_range();
+
+  (input_range, expanded_range)
+}
+
+/// The outer block of the expanded function body must keep the exact
+/// source byte range of the user-written body -- i.e. expansion must
+/// *not* wrap it in a fresh, call-site-spanned block.
+#[test]
+fn preserves_body_span() {
+  let src = "\
+#[test_log::test]
+fn it_works() {
+    let _x = 1;
+}
+";
+  let (input, expanded) = expand_and_get_brace_ranges(src);
+  assert_eq!(input, expanded, "body braces must retain their source span");
+}
+
+/// Same invariant when forwarding to an inner test attribute such as
+/// `tokio::test`.
+#[test]
+fn preserves_body_span_with_inner_attribute() {
+  let src = "\
+#[test_log::test(tokio::test)]
+async fn it_works() {
+    let _x = 1;
+}
+";
+  let (input, expanded) = expand_and_get_brace_ranges(src);
+  assert_eq!(input, expanded, "body braces must retain their source span");
+}
+
+/// Same invariant for functions with an explicit return type.
+#[test]
+fn preserves_body_span_with_return_type() {
+  let src = "\
+#[test_log::test]
+fn returns_result() -> Result<(), String> {
+    Ok(())
+}
+";
+  let (input, expanded) = expand_and_get_brace_ranges(src);
+  assert_eq!(input, expanded, "body braces must retain their source span");
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -177,6 +177,23 @@ impl<T> Foo for T {}
 #[test_log::test]
 fn unambiguous_map() {}
 
+// The macro-injected `init` module shouldn't affect the scope of user code.
+mod init {
+  pub const VALUE: u32 = 6;
+}
+
+#[test_log::test]
+fn outer_mod_init() {
+  assert_eq!(init::VALUE, 6);
+}
+
+#[test_log::test]
+fn inner_mod_init() {
+  mod init {
+    pub const VALUE: u32 = 7;
+  }
+  assert_eq!(init::VALUE, 7);
+}
 
 /// A module used for testing the `test` attribute after importing it
 /// via `use` instead of using fuller qualified syntax.


### PR DESCRIPTION
I have a project that uses test-log with this attribute:

```rust
#[test_log::test(tokio::test(start_paused = true))]
```

I've noticed that when I try to use jump-to-definition from inside the test to a name outside of it, I get a bunch of unrelated definitions:

```
/Users/jorendorff/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/lib.rs
1:#![allow(
/Users/jorendorff/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/builder.rs
  53:pub struct Builder {
 246:    pub fn new_current_thread() -> Builder {
 351:    pub fn enable_all(&mut self) -> &mut Self {
 985:    pub fn build(&mut self) -> io::Result<Runtime> {
1766:        pub fn start_paused(&mut self, start_paused: bool) -> &mut Self {
/Users/jorendorff/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/mod.rs
1://! The Tokio runtime.
/Users/jorendorff/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/runtime.rs
340:    pub fn block_on<F: Future>(&self, future: F) -> F::Output {
/Users/jorendorff/.rustup/toolchains/1.94.1-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/result.rs
1179:    pub fn expect(self, msg: &str) -> T
/Users/jorendorff/.rustup/toolchains/1.94.1-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/macros.rs
14:macro_rules! panic {
crates/query/src/lexical/test_mini.rs
24:pub struct LexicalMiniIndex {
```

The last item is the definition I'm actually looking for.

This turns out to be a known rust-analyzer issue, rust-lang/rust-analyzer#20441. The fix is to make sure your procedural macro does not change the spans of the original test.

In this PR:

- Don't use `quote!` to add more curly braces; instead reuse the original `{}` tokens. This fixes rust-analyzer for me.
- To keep that from potentially causing scoping problems, wrap the `mod init` and the `init::init();` call in a block. (As a side effect, this will make test-log work even if a test happens to contain a `mod init`, something that would have failed before.)

Note: I didn't see any contributor instructions, so I just followed the existing practice and added a copyright notice with my name at the top of the new test file. If you need me to remove it, that's no problem.

Full disclosure: I used AI to make this, but I also read it all and trimmed stuff and changed things, and I can vouch for every line.